### PR TITLE
Updates to code

### DIFF
--- a/UIDevice-Hardware.h
+++ b/UIDevice-Hardware.h
@@ -22,7 +22,9 @@
 #define IPOD_UNKNOWN_NAMESTRING			@"Unknown iPod"
 
 #define IPAD_1G_NAMESTRING				@"iPad 1G"
-#define IPAD_2G_NAMESTRING				@"iPad 2G"
+#define IPAD_2G_WIFI_NAMESTRING			@"iPad 2G (WiFi)"
+#define IPAD_2G_3G_GSM_NAMESTRING		@"iPad 2G (3G GSM)"
+#define IPAD_2G_3G_CDMA_NAMESTRING		@"iPad 2G (3G CDMA)"
 #define IPAD_UNKNOWN_NAMESTRING			@"Unknown iPad"
 
 // Nano? Apple TV?
@@ -53,7 +55,9 @@ typedef enum {
 	UIDevice4GiPod,
 	
 	UIDevice1GiPad, // both regular and 3G
-	UIDevice2GiPad,
+	UIDevice2GiPadWiFi,
+	UIDevice2GiPad3GGSM,
+	UIDevice2GiPad3GCDMA,
 	
 	UIDeviceAppleTV2,
 	

--- a/UIDevice-Hardware.h
+++ b/UIDevice-Hardware.h
@@ -9,34 +9,33 @@
 typedef enum {
 	UIDeviceUnknown                 = 0x000000,
 	
-	UIDeviceiPhoneSimulatoriPhone   = 0x000001, // both regular and iPhone 4 devices
-	UIDeviceiPhoneSimulatoriPad     = 0x000002,
+	UIDeviceSimulatorIPhone         = 0x000001, // both regular and iPhone 4 devices
+	UIDeviceSimulatorIPad           = 0x000002,
 	
-	UIDevice1GiPhone                = 0x000004,
-	UIDevice3GiPhone                = 0x000008,
-	UIDevice3GSiPhone               = 0x000010,
-	UIDevice4iPhoneGSM              = 0x000020,
-	UIDevice4iPhoneCDMA             = 0x000040,
-	UIDevice5iPhone                 = 0x000080,
+	UIDeviceIPhone1G                = 0x000004,
+	UIDeviceIPhone3G                = 0x000008,
+	UIDeviceIPhone3GS               = 0x000010,
+	UIDeviceIPhone4_GSM             = 0x000020,
+	UIDeviceIPhone4_CDMA            = 0x000040,
+	UIDeviceIPhone5                 = 0x000080,
+
+	UIDeviceIPod1G                  = 0x000100,
+	UIDeviceIPod2G                  = 0x000200,
+	UIDeviceIPod3G                  = 0x000300,
+	UIDeviceIPod4G                  = 0x000400,
 	
-	UIDevice1GiPod                  = 0x000100,
-	UIDevice2GiPod                  = 0x000200,
-	UIDevice3GiPod                  = 0x000300,
-	UIDevice4GiPod                  = 0x000400,
-	
-	UIDevice1GiPad                  = 0x000800, // both regular and 3G
-	UIDevice2GiPadWiFi              = 0x001000,
-	UIDevice2GiPad3GGSM             = 0x002000,
-	UIDevice2GiPad3GCDMA            = 0x004000,
+	UIDeviceIPad1                   = 0x000800, // both regular and 3G, needs verification.
+	UIDeviceIPad2_WiFi              = 0x001000,
+	UIDeviceIPad2_3G_GSM            = 0x002000,
+	UIDeviceIPad2_3G_CDMA           = 0x004000,
 	
 	UIDeviceAppleTV2                = 0x008000,
 	
 	UIDeviceUnknownSimulator        = 0x010000,
-	UIDeviceUnknowniPhone           = 0x020000,
-	UIDeviceUnknowniPod             = 0x040000,
-	UIDeviceUnknowniPad             = 0x080000,
+	UIDeviceUnknownIPhone           = 0x020000,
+	UIDeviceUnknownIPod             = 0x040000,
+	UIDeviceUnknownIPad             = 0x080000,
 	UIDeviceIFPGA                   = 0x100000,
-
 } UIDevicePlatform;
 
 @interface UIDevice (Hardware)

--- a/UIDevice-Hardware.h
+++ b/UIDevice-Hardware.h
@@ -38,35 +38,35 @@
 #define IPHONE_SIMULATOR_IPAD_NAMESTRING	@"iPad Simulator"
 
 typedef enum {
-	UIDeviceUnknown,
+	UIDeviceUnknown                 = 0x000000,
 	
-	UIDeviceiPhoneSimulator,
-	UIDeviceiPhoneSimulatoriPhone, // both regular and iPhone 4 devices
-	UIDeviceiPhoneSimulatoriPad,
+	UIDeviceiPhoneSimulatoriPhone   = 0x000001, // both regular and iPhone 4 devices
+	UIDeviceiPhoneSimulatoriPad     = 0x000002,
 	
-	UIDevice1GiPhone,
-	UIDevice3GiPhone,
-	UIDevice3GSiPhone,
-	UIDevice4iPhoneGSM,
-	UIDevice4iPhoneCDMA,
-	UIDevice5iPhone,
+	UIDevice1GiPhone                = 0x000004,
+	UIDevice3GiPhone                = 0x000008,
+	UIDevice3GSiPhone               = 0x000010,
+	UIDevice4iPhoneGSM              = 0x000020,
+	UIDevice4iPhoneCDMA             = 0x000040,
+	UIDevice5iPhone                 = 0x000080,
 	
-	UIDevice1GiPod,
-	UIDevice2GiPod,
-	UIDevice3GiPod,
-	UIDevice4GiPod,
+	UIDevice1GiPod                  = 0x000100,
+	UIDevice2GiPod                  = 0x000200,
+	UIDevice3GiPod                  = 0x000300,
+	UIDevice4GiPod                  = 0x000400,
 	
-	UIDevice1GiPad, // both regular and 3G
-	UIDevice2GiPadWiFi,
-	UIDevice2GiPad3GGSM,
-	UIDevice2GiPad3GCDMA,
+	UIDevice1GiPad                  = 0x000800, // both regular and 3G
+	UIDevice2GiPadWiFi              = 0x001000,
+	UIDevice2GiPad3GGSM             = 0x002000,
+	UIDevice2GiPad3GCDMA            = 0x004000,
 	
-	UIDeviceAppleTV2,
+	UIDeviceAppleTV2                = 0x008000,
 	
-	UIDeviceUnknowniPhone,
-	UIDeviceUnknowniPod,
-	UIDeviceUnknowniPad,
-	UIDeviceIFPGA,
+	UIDeviceUnknownSimulator        = 0x010000,
+	UIDeviceUnknowniPhone           = 0x020000,
+	UIDeviceUnknowniPod             = 0x040000,
+	UIDeviceUnknowniPad             = 0x080000,
+	UIDeviceIFPGA                   = 0x100000,
 
 } UIDevicePlatform;
 

--- a/UIDevice-Hardware.h
+++ b/UIDevice-Hardware.h
@@ -38,6 +38,26 @@ typedef enum {
 	UIDeviceIFPGA                   = 0x100000,
 } UIDevicePlatform;
 
+#define UIDEVICE_PLATFORM_MASK_IPHONE3 (UIDeviceIPhone3G | UIDeviceIPhone3GS)
+#define UIDEVICE_PLATFORM_MASK_IPHONE4 (UIDeviceIPhone4_GSM | UIDeviceIPhone4_CDMA)
+#define UIDEVICE_PLATFORM_MASK_IPHONE (UIDeviceIPhone1G | UIDEVICE_PLATFORM_IPHONE3 | UIDEVICE_PLATFORM_IPHONE4 | UIDeviceIPhone5 | UIDeviceSimulatorIPhone | UIDeviceUnknownIPhone)
+#define UIDEVICE_PLATFORM_MASK_IPOD (UIDeviceIPod1G | UIDeviceIPod2G | UIDeviceIPod3G | UIDeviceIPod4G | UIDeviceUnknownIPod)
+#define UIDEVICE_PLATFORM_MASK_IPAD (UIDeviceIPad1 | UIDeviceIPad2_WiFi | UIDeviceIPad2_3G_GSM | UIDeviceIPad2_3G_CDMA | UIDeviceSimulatorIPad | UIDeviceUnknownIPad)
+#define UIDEVICE_PLATFORM_MASK_UNKNOWN (UIDeviceUnknownSimulator | UIDeviceUnknownIPhone | UIDeviceUnknownIPod | UIDeviceUnknownIPad)
+
+/* Use these macros to recognize families of devices. Usage:
+ * if (UIDEVICE_PLATFORMTYPE_IS_IPHONE([[UIDevice currentDevice] platformType])) {
+ *   do_iphone_specific_stuff();
+ * }
+ */
+
+#define UIDEVICE_PLATFORMTYPE_IS_IPHONE3(type) ((type & UIDEVICE_PLATFORM_MASK_IPHONE3) != 0)
+#define UIDEVICE_PLATFORMTYPE_IS_IPHONE4(type) ((type & UIDEVICE_PLATFORM_MASK_IPHONE4) != 0)
+#define UIDEVICE_PLATFORMTYPE_IS_IPHONE(type) ((type & UIDEVICE_PLATFORM_MASK_IPHONE) != 0)
+#define UIDEVICE_PLATFORMTYPE_IS_IPOD(type) ((type & UIDEVICE_PLATFORM_MASK_IPOD) != 0)
+#define UIDEVICE_PLATFORMTYPE_IS_IPAD(type) ((type & UIDEVICE_PLATFORM_MASK_IPAD) != 0)
+#define UIDEVICE_PLATFORMTYPE_IS_UNKNOWN(type) ((type & UIDEVICE_PLATFORM_MASK_UNKNOWN) != 0)
+
 @interface UIDevice (Hardware)
 - (NSString *) platform;
 - (NSString *) hwmodel;

--- a/UIDevice-Hardware.h
+++ b/UIDevice-Hardware.h
@@ -6,37 +6,6 @@
 
 #import <UIKit/UIKit.h>
 
-#define IFPGA_NAMESTRING				@"iFPGA"
-
-#define IPHONE_1G_NAMESTRING			@"iPhone 1G"
-#define IPHONE_3G_NAMESTRING			@"iPhone 3G"
-#define IPHONE_3GS_NAMESTRING			@"iPhone 3GS" 
-#define IPHONE_4_GSM_NAMESTRING         @"iPhone 4 (GSM)"
-#define IPHONE_4_CDMA_NAMESTRING        @"iPhone 4 (CDMA)"
-#define IPHONE_5_NAMESTRING				@"iPhone 5"
-#define IPHONE_UNKNOWN_NAMESTRING		@"Unknown iPhone"
-
-#define IPOD_1G_NAMESTRING				@"iPod touch 1G"
-#define IPOD_2G_NAMESTRING				@"iPod touch 2G"
-#define IPOD_3G_NAMESTRING				@"iPod touch 3G"
-#define IPOD_4G_NAMESTRING				@"iPod touch 4G"
-#define IPOD_UNKNOWN_NAMESTRING			@"Unknown iPod"
-
-#define IPAD_1G_NAMESTRING				@"iPad 1G"
-#define IPAD_2G_WIFI_NAMESTRING			@"iPad 2G (WiFi)"
-#define IPAD_2G_3G_GSM_NAMESTRING		@"iPad 2G (3G GSM)"
-#define IPAD_2G_3G_CDMA_NAMESTRING		@"iPad 2G (3G CDMA)"
-#define IPAD_UNKNOWN_NAMESTRING			@"Unknown iPad"
-
-// Nano? Apple TV?
-#define APPLETV_2G_NAMESTRING			@"Apple TV 2G"
-
-#define IPOD_FAMILY_UNKNOWN_DEVICE			@"Unknown iOS device"
-
-#define IPHONE_SIMULATOR_NAMESTRING			@"iPhone Simulator"
-#define IPHONE_SIMULATOR_IPHONE_NAMESTRING	@"iPhone Simulator"
-#define IPHONE_SIMULATOR_IPAD_NAMESTRING	@"iPad Simulator"
-
 typedef enum {
 	UIDeviceUnknown                 = 0x000000,
 	

--- a/UIDevice-Hardware.h
+++ b/UIDevice-Hardware.h
@@ -11,7 +11,8 @@
 #define IPHONE_1G_NAMESTRING			@"iPhone 1G"
 #define IPHONE_3G_NAMESTRING			@"iPhone 3G"
 #define IPHONE_3GS_NAMESTRING			@"iPhone 3GS" 
-#define IPHONE_4_NAMESTRING				@"iPhone 4" 
+#define IPHONE_4_GSM_NAMESTRING         @"iPhone 4 (GSM)"
+#define IPHONE_4_CDMA_NAMESTRING        @"iPhone 4 (CDMA)"
 #define IPHONE_5_NAMESTRING				@"iPhone 5"
 #define IPHONE_UNKNOWN_NAMESTRING		@"Unknown iPhone"
 
@@ -46,7 +47,8 @@ typedef enum {
 	UIDevice1GiPhone,
 	UIDevice3GiPhone,
 	UIDevice3GSiPhone,
-	UIDevice4iPhone,
+	UIDevice4iPhoneGSM,
+	UIDevice4iPhoneCDMA,
 	UIDevice5iPhone,
 	
 	UIDevice1GiPod,

--- a/UIDevice-Hardware.m
+++ b/UIDevice-Hardware.m
@@ -37,7 +37,9 @@
  
  iPad1,1   -> iPad 1G, WiFi
  iPad1,?   -> iPad 1G, 3G <- needs 3G owner to test
- iPad2,1   -> iPad 2G (iProd 2,1)
+ iPad2,1   -> iPad 2G, WiFi
+ iPad2,2   -> iPad 2G, 3G GSM
+ iPad2,3   -> iPad 2G, 3G CDMA
  
  AppleTV2,1 -> AppleTV 2
 
@@ -127,7 +129,7 @@
 
 	if ([platform isEqualToString:@"iPhone1,1"])	return UIDevice1GiPhone;
 	if ([platform isEqualToString:@"iPhone1,2"])	return UIDevice3GiPhone;
-	if ([platform hasPrefix:@"iPhone2"])	return UIDevice3GSiPhone;
+	if ([platform hasPrefix:@"iPhone2"])			return UIDevice3GSiPhone;
 	if ([platform hasPrefix:@"iPhone3"])			return UIDevice4iPhone;
 	if ([platform hasPrefix:@"iPhone4"])			return UIDevice5iPhone;
 	
@@ -137,7 +139,9 @@
 	if ([platform isEqualToString:@"iPod4,1"])   return UIDevice4GiPod;
 		
 	if ([platform isEqualToString:@"iPad1,1"])   return UIDevice1GiPad;
-	if ([platform isEqualToString:@"iPad2,1"])   return UIDevice2GiPad;
+	if ([platform isEqualToString:@"iPad2,1"])   return UIDevice2GiPadWiFi;
+	if ([platform isEqualToString:@"iPad2,2"])   return UIDevice2GiPad3GGSM;
+	if ([platform isEqualToString:@"iPad2,3"])   return UIDevice2GiPad3GCDMA;
 	
 	if ([platform isEqualToString:@"AppleTV2,1"])	return UIDeviceAppleTV2;
 	
@@ -179,7 +183,9 @@
 		case UIDeviceUnknowniPod: return IPOD_UNKNOWN_NAMESTRING;
 			
 		case UIDevice1GiPad : return IPAD_1G_NAMESTRING;
-		case UIDevice2GiPad : return IPAD_2G_NAMESTRING;
+		case UIDevice2GiPadWiFi : return IPAD_2G_WIFI_NAMESTRING;
+		case UIDevice2GiPad3GGSM : return IPAD_2G_3G_GSM_NAMESTRING;
+		case UIDevice2GiPad3GCDMA : return IPAD_2G_3G_CDMA_NAMESTRING;
 			
 		case UIDeviceAppleTV2 : return APPLETV_2G_NAMESTRING;
 			
@@ -259,7 +265,9 @@
 		case UIDeviceUnknowniPod: return IPOD_UNKNOWN_NAMESTRING;
 			
 		case UIDevice1GiPad: return @"K48";
-		case UIDevice2GiPad: return IPAD_UNKNOWN_NAMESTRING;
+		case UIDevice2GiPadWiFi: return @"K93";
+		case UIDevice2GiPad3GGSM: return @"K94";
+		case UIDevice2GiPad3GCDMA: return @"K95";
 		case UIDeviceUnknowniPad: return IPAD_UNKNOWN_NAMESTRING;
 			
 		case UIDeviceAppleTV2:	return @"K66";

--- a/UIDevice-Hardware.m
+++ b/UIDevice-Hardware.m
@@ -47,36 +47,16 @@
 @implementation UIDevice (Hardware)
 
 /*
- Platforms
- 
- iFPGA ->		??
-
- iPhone1,1 ->	iPhone 1G
- iPhone1,2 ->	iPhone 3G
- iPhone2,1 ->	iPhone 3GS
- iPhone3,1 ->	iPhone 4/AT&T (GSM)
- iPhone3,2 ->	??iPhone 4/Unknown
- iPhone3,3 ->	iPhone 4/Verizon Wireless (CDMA)
- iPhone4,1 ->	??iPhone 5
-
- iPod1,1   -> iPod touch 1G 
- iPod2,1   -> iPod touch 2G 
- iPod2,2   -> ??iPod touch 2.5G
- iPod3,1   -> iPod touch 3G
- iPod4,1   -> iPod touch 4G
- iPod5,1   -> ??iPod touch 5G
- 
- iPad1,1   -> iPad 1G, WiFi
- iPad1,?   -> iPad 1G, 3G <- needs 3G owner to test
- iPad2,1   -> iPad 2G, WiFi
- iPad2,2   -> iPad 2G, 3G GSM
- iPad2,3   -> iPad 2G, 3G CDMA
- 
- AppleTV2,1 -> AppleTV 2
-
- i386, x86_64 -> iPhone Simulator
-*/
-
+ * These are platforms returned by the hw.machine sysctl that we don't really know what to think about.
+ * 
+ * iPhone3,2    -> iPhone 4/Unknown (3,1 is GSM, 3,3 is CDMA - possibly a secondary CDMA model)
+ * iPod2,2      -> iPod Touch 2.5G ??
+ * iPad1,?      -> iPad 1G, 3G. (Needs 3G owner to verify)
+ *
+ * iFPGA        -> ??
+ * iPhone4,1    -> iPhone 5 ?? (Unreleased)
+ * iPod5,1      -> iPod Touch 5G (Unreleased)
+ */
 
 #pragma mark sysctlbyname utils
 - (NSString *) getSysInfoByName:(char *)typeSpecifier

--- a/UIDevice-Hardware.m
+++ b/UIDevice-Hardware.m
@@ -13,6 +13,37 @@
 
 #import "UIDevice-Hardware.h"
 
+
+#define IFPGA_NAMESTRING				@"iFPGA"
+
+#define IPHONE_1G_NAMESTRING			@"iPhone 1G"
+#define IPHONE_3G_NAMESTRING			@"iPhone 3G"
+#define IPHONE_3GS_NAMESTRING			@"iPhone 3GS" 
+#define IPHONE_4_GSM_NAMESTRING         @"iPhone 4 (GSM)"
+#define IPHONE_4_CDMA_NAMESTRING        @"iPhone 4 (CDMA)"
+#define IPHONE_5_NAMESTRING				@"iPhone 5"
+#define IPHONE_UNKNOWN_NAMESTRING		@"Unknown iPhone"
+
+#define IPOD_1G_NAMESTRING				@"iPod touch 1G"
+#define IPOD_2G_NAMESTRING				@"iPod touch 2G"
+#define IPOD_3G_NAMESTRING				@"iPod touch 3G"
+#define IPOD_4G_NAMESTRING				@"iPod touch 4G"
+#define IPOD_UNKNOWN_NAMESTRING			@"Unknown iPod"
+
+#define IPAD_1G_NAMESTRING				@"iPad 1G"
+#define IPAD_2G_WIFI_NAMESTRING			@"iPad 2G (WiFi)"
+#define IPAD_2G_3G_GSM_NAMESTRING		@"iPad 2G (3G GSM)"
+#define IPAD_2G_3G_CDMA_NAMESTRING		@"iPad 2G (3G CDMA)"
+#define IPAD_UNKNOWN_NAMESTRING			@"Unknown iPad"
+
+#define APPLETV_2G_NAMESTRING			@"Apple TV 2G"
+
+#define IPOD_FAMILY_UNKNOWN_DEVICE			@"Unknown iOS device"
+
+#define IPHONE_SIMULATOR_NAMESTRING			@"iPhone Simulator"
+#define IPHONE_SIMULATOR_IPHONE_NAMESTRING	@"iPhone Simulator"
+#define IPHONE_SIMULATOR_IPAD_NAMESTRING	@"iPad Simulator"
+
 @implementation UIDevice (Hardware)
 
 /*

--- a/UIDevice-Hardware.m
+++ b/UIDevice-Hardware.m
@@ -155,41 +155,40 @@
 {
 	NSString *platform = [self platform];
 	
-	if ([platform isEqualToString:@"iFPGA"])		return UIDeviceIFPGA;
+	if ([platform isEqualToString:@"iFPGA"])        return UIDeviceIFPGA;
 
-	if ([platform isEqualToString:@"iPhone1,1"])	return UIDevice1GiPhone;
-	if ([platform isEqualToString:@"iPhone1,2"])	return UIDevice3GiPhone;
-	if ([platform hasPrefix:@"iPhone2"])			return UIDevice3GSiPhone;
-	if ([platform isEqualToString:@"iPhone3,1"])    return UIDevice4iPhoneGSM;
-	if ([platform isEqualToString:@"iPhone3,3"])    return UIDevice4iPhoneCDMA;
-	if ([platform hasPrefix:@"iPhone4"])			return UIDevice5iPhone;
+	if ([platform isEqualToString:@"iPhone1,1"])    return UIDeviceIPhone1G;
+	if ([platform isEqualToString:@"iPhone1,2"])    return UIDeviceIPhone3G;
+	if ([platform hasPrefix:@"iPhone2"])            return UIDeviceIPhone3GS;
+	if ([platform isEqualToString:@"iPhone3,1"])    return UIDeviceIPhone4_GSM;
+	if ([platform isEqualToString:@"iPhone3,3"])    return UIDeviceIPhone4_CDMA;
+	if ([platform hasPrefix:@"iPhone4"])            return UIDeviceIPhone5;
 	
-	if ([platform isEqualToString:@"iPod1,1"])   return UIDevice1GiPod;
-	if ([platform isEqualToString:@"iPod2,1"])   return UIDevice2GiPod;
-	if ([platform isEqualToString:@"iPod3,1"])   return UIDevice3GiPod;
-	if ([platform isEqualToString:@"iPod4,1"])   return UIDevice4GiPod;
-		
-	if ([platform isEqualToString:@"iPad1,1"])   return UIDevice1GiPad;
-	if ([platform isEqualToString:@"iPad2,1"])   return UIDevice2GiPadWiFi;
-	if ([platform isEqualToString:@"iPad2,2"])   return UIDevice2GiPad3GGSM;
-	if ([platform isEqualToString:@"iPad2,3"])   return UIDevice2GiPad3GCDMA;
-	
-	if ([platform isEqualToString:@"AppleTV2,1"])	return UIDeviceAppleTV2;
-	
+	if ([platform isEqualToString:@"iPod1,1"])      return UIDeviceIPod1G;
+	if ([platform isEqualToString:@"iPod2,1"])      return UIDeviceIPod2G;
+	if ([platform isEqualToString:@"iPod3,1"])      return UIDeviceIPod3G;
+	if ([platform isEqualToString:@"iPod4,1"])      return UIDeviceIPod4G;
+
 	/*
-	 MISSING A SOLUTION HERE TO DATE TO DIFFERENTIATE iPAD and iPAD 3G.... SORRY!
+	 TODO: MISSING A SOLUTION HERE TO DIFFERENTIATE iPAD 1 and iPAD 1 3G.... SORRY!
 	 */
+	if ([platform isEqualToString:@"iPad1,1"])      return UIDeviceIPad1;
+	if ([platform isEqualToString:@"iPad2,1"])      return UIDeviceIPad2_WiFi;
+	if ([platform isEqualToString:@"iPad2,2"])      return UIDeviceIPad2_3G_GSM;
+	if ([platform isEqualToString:@"iPad2,3"])      return UIDeviceIPad2_3G_CDMA;
 
-	if ([platform hasPrefix:@"iPhone"]) return UIDeviceUnknowniPhone;
-	if ([platform hasPrefix:@"iPod"]) return UIDeviceUnknowniPod;
-	if ([platform hasPrefix:@"iPad"]) return UIDeviceUnknowniPad;
+	if ([platform isEqualToString:@"AppleTV2,1"])   return UIDeviceAppleTV2;
+
+	if ([platform hasPrefix:@"iPhone"])             return UIDeviceUnknownIPhone;
+	if ([platform hasPrefix:@"iPod"])               return UIDeviceUnknownIPod;
+	if ([platform hasPrefix:@"iPad"])               return UIDeviceUnknownIPad;
 	
 	if ([platform hasSuffix:@"86"] || [platform isEqual:@"x86_64"]) // thanks Jordan Breeding
 	{
 		if ([[UIScreen mainScreen] bounds].size.width < 768)
-			return UIDeviceiPhoneSimulatoriPhone;
+			return UIDeviceSimulatorIPhone;
 		else 
-			return UIDeviceiPhoneSimulatoriPad;
+			return UIDeviceSimulatorIPad;
 
 		return UIDeviceUnknownSimulator;
 	}
@@ -201,32 +200,34 @@
 {
 	switch ([self platformType])
 	{
-		case UIDevice1GiPhone: return IPHONE_1G_NAMESTRING;
-		case UIDevice3GiPhone: return IPHONE_3G_NAMESTRING;
-		case UIDevice3GSiPhone:	return IPHONE_3GS_NAMESTRING;
-		case UIDevice4iPhoneGSM:        return IPHONE_4_GSM_NAMESTRING;
-		case UIDevice4iPhoneCDMA:       return IPHONE_4_CDMA_NAMESTRING;
-		case UIDevice5iPhone:	return IPHONE_5_NAMESTRING;
-		case UIDeviceUnknowniPhone: return IPHONE_UNKNOWN_NAMESTRING;
+		case UIDeviceIPhone1G:      return IPHONE_1G_NAMESTRING;
+		case UIDeviceIPhone3G:      return IPHONE_3G_NAMESTRING;
+		case UIDeviceIPhone3GS:     return IPHONE_3GS_NAMESTRING;
+		case UIDeviceIPhone4_GSM:   return IPHONE_4_GSM_NAMESTRING;
+		case UIDeviceIPhone4_CDMA:  return IPHONE_4_CDMA_NAMESTRING;
+		case UIDeviceIPhone5:       return IPHONE_5_NAMESTRING;
 		
-		case UIDevice1GiPod: return IPOD_1G_NAMESTRING;
-		case UIDevice2GiPod: return IPOD_2G_NAMESTRING;
-		case UIDevice3GiPod: return IPOD_3G_NAMESTRING;
-		case UIDevice4GiPod: return IPOD_4G_NAMESTRING;
-		case UIDeviceUnknowniPod: return IPOD_UNKNOWN_NAMESTRING;
+		case UIDeviceIPod1G:        return IPOD_1G_NAMESTRING;
+		case UIDeviceIPod2G:        return IPOD_2G_NAMESTRING;
+		case UIDeviceIPod3G:        return IPOD_3G_NAMESTRING;
+		case UIDeviceIPod4G:        return IPOD_4G_NAMESTRING;
+
+		case UIDeviceIPad1:         return IPAD_1G_NAMESTRING;
+		case UIDeviceIPad2_WiFi:    return IPAD_2G_WIFI_NAMESTRING;
+		case UIDeviceIPad2_3G_GSM:  return IPAD_2G_3G_GSM_NAMESTRING;
+		case UIDeviceIPad2_3G_CDMA: return IPAD_2G_3G_CDMA_NAMESTRING;
 			
-		case UIDevice1GiPad : return IPAD_1G_NAMESTRING;
-		case UIDevice2GiPadWiFi : return IPAD_2G_WIFI_NAMESTRING;
-		case UIDevice2GiPad3GGSM : return IPAD_2G_3G_GSM_NAMESTRING;
-		case UIDevice2GiPad3GCDMA : return IPAD_2G_3G_CDMA_NAMESTRING;
+		case UIDeviceAppleTV2:      return APPLETV_2G_NAMESTRING;
 			
-		case UIDeviceAppleTV2 : return APPLETV_2G_NAMESTRING;
-			
-		case UIDeviceUnknownSimulator: return IPHONE_SIMULATOR_NAMESTRING;
-		case UIDeviceiPhoneSimulatoriPhone: return IPHONE_SIMULATOR_IPHONE_NAMESTRING;
-		case UIDeviceiPhoneSimulatoriPad: return IPHONE_SIMULATOR_IPAD_NAMESTRING;
-			
-		case UIDeviceIFPGA: return IFPGA_NAMESTRING;
+		case UIDeviceSimulatorIPhone:   return IPHONE_SIMULATOR_IPHONE_NAMESTRING;
+		case UIDeviceSimulatorIPad:     return IPHONE_SIMULATOR_IPAD_NAMESTRING;
+
+        case UIDeviceUnknownIPhone:     return IPHONE_UNKNOWN_NAMESTRING;
+		case UIDeviceUnknownIPod:       return IPOD_UNKNOWN_NAMESTRING;
+		case UIDeviceUnknownIPad:       return IPAD_UNKNOWN_NAMESTRING;
+        case UIDeviceUnknownSimulator:  return IPHONE_SIMULATOR_NAMESTRING;
+
+		case UIDeviceIFPGA:             return IFPGA_NAMESTRING;
 			
 		default: return IPOD_FAMILY_UNKNOWN_DEVICE;
 	}
@@ -284,30 +285,30 @@
 {
 	switch ([self platformType])
 	{
-		case UIDevice1GiPhone: return @"M68";
-		case UIDevice3GiPhone: return @"N82";
-		case UIDevice3GSiPhone:	return @"N88";
-		case UIDevice4iPhoneGSM: return @"N89";
-		case UIDevice4iPhoneCDMA: return @"N92";
-		case UIDevice5iPhone: return IPHONE_UNKNOWN_NAMESTRING;
-		case UIDeviceUnknowniPhone: return IPHONE_UNKNOWN_NAMESTRING;
+		case UIDeviceIPhone1G:      return @"M68";
+		case UIDeviceIPhone3G:      return @"N82";
+		case UIDeviceIPhone3GS:     return @"N88";
+		case UIDeviceIPhone4_GSM:   return @"N89";
+		case UIDeviceIPhone4_CDMA:  return @"N92";
+		case UIDeviceIPhone5:       return IPHONE_UNKNOWN_NAMESTRING;
 			
-		case UIDevice1GiPod: return @"N45";
-		case UIDevice2GiPod: return @"N72";
-		case UIDevice3GiPod: return @"N18"; 
-		case UIDevice4GiPod: return @"N80";
-		case UIDeviceUnknowniPod: return IPOD_UNKNOWN_NAMESTRING;
-			
-		case UIDevice1GiPad: return @"K48";
-		case UIDevice2GiPadWiFi: return @"K93";
-		case UIDevice2GiPad3GGSM: return @"K94";
-		case UIDevice2GiPad3GCDMA: return @"K95";
-		case UIDeviceUnknowniPad: return IPAD_UNKNOWN_NAMESTRING;
-			
-		case UIDeviceAppleTV2:	return @"K66";
+		case UIDeviceIPod1G:        return @"N45";
+		case UIDeviceIPod2G:        return @"N72";
+		case UIDeviceIPod3G:        return @"N18";
+		case UIDeviceIPod4G:        return @"N80";
 
-		case UIDeviceUnknownSimulator: return IPHONE_SIMULATOR_NAMESTRING;
-			
+		case UIDeviceIPad1:         return @"K48";
+		case UIDeviceIPad2_WiFi:    return @"K93";
+		case UIDeviceIPad2_3G_GSM:  return @"K94";
+		case UIDeviceIPad2_3G_CDMA: return @"K95";
+
+		case UIDeviceAppleTV2:      return @"K66";
+
+		case UIDeviceUnknownIPhone:     return IPHONE_UNKNOWN_NAMESTRING;
+		case UIDeviceUnknownIPod:       return IPOD_UNKNOWN_NAMESTRING;
+		case UIDeviceUnknownIPad:       return IPAD_UNKNOWN_NAMESTRING;
+		case UIDeviceUnknownSimulator:  return IPHONE_SIMULATOR_NAMESTRING;
+
 		default: return IPOD_FAMILY_UNKNOWN_DEVICE;
 	}
 }

--- a/UIDevice-Hardware.m
+++ b/UIDevice-Hardware.m
@@ -23,9 +23,9 @@
  iPhone1,1 ->	iPhone 1G
  iPhone1,2 ->	iPhone 3G
  iPhone2,1 ->	iPhone 3GS
- iPhone3,1 ->	iPhone 4/AT&T
- iPhone3,2 ->	iPhone 4/Other Carrier?
- iPhone3,3 ->	iPhone 4/Other Carrier?
+ iPhone3,1 ->	iPhone 4/AT&T (GSM)
+ iPhone3,2 ->	??iPhone 4/Unknown
+ iPhone3,3 ->	iPhone 4/Verizon Wireless (CDMA)
  iPhone4,1 ->	??iPhone 5
 
  iPod1,1   -> iPod touch 1G 
@@ -129,7 +129,8 @@
 	if ([platform isEqualToString:@"iPhone1,1"])	return UIDevice1GiPhone;
 	if ([platform isEqualToString:@"iPhone1,2"])	return UIDevice3GiPhone;
 	if ([platform hasPrefix:@"iPhone2"])			return UIDevice3GSiPhone;
-	if ([platform hasPrefix:@"iPhone3"])			return UIDevice4iPhone;
+	if ([platform isEqualToString:@"iPhone3,1"])    return UIDevice4iPhoneGSM;
+	if ([platform isEqualToString:@"iPhone3,3"])    return UIDevice4iPhoneCDMA;
 	if ([platform hasPrefix:@"iPhone4"])			return UIDevice5iPhone;
 	
 	if ([platform isEqualToString:@"iPod1,1"])   return UIDevice1GiPod;
@@ -172,7 +173,8 @@
 		case UIDevice1GiPhone: return IPHONE_1G_NAMESTRING;
 		case UIDevice3GiPhone: return IPHONE_3G_NAMESTRING;
 		case UIDevice3GSiPhone:	return IPHONE_3GS_NAMESTRING;
-		case UIDevice4iPhone:	return IPHONE_4_NAMESTRING;
+		case UIDevice4iPhoneGSM:        return IPHONE_4_GSM_NAMESTRING;
+		case UIDevice4iPhoneCDMA:       return IPHONE_4_CDMA_NAMESTRING;
 		case UIDevice5iPhone:	return IPHONE_5_NAMESTRING;
 		case UIDeviceUnknowniPhone: return IPHONE_UNKNOWN_NAMESTRING;
 		
@@ -254,7 +256,8 @@
 		case UIDevice1GiPhone: return @"M68";
 		case UIDevice3GiPhone: return @"N82";
 		case UIDevice3GSiPhone:	return @"N88";
-		case UIDevice4iPhone: return @"N89";
+		case UIDevice4iPhoneGSM: return @"N89";
+		case UIDevice4iPhoneCDMA: return @"N92";
 		case UIDevice5iPhone: return IPHONE_UNKNOWN_NAMESTRING;
 		case UIDeviceUnknowniPhone: return IPHONE_UNKNOWN_NAMESTRING;
 			

--- a/UIDevice-Hardware.m
+++ b/UIDevice-Hardware.m
@@ -160,7 +160,7 @@
 		else 
 			return UIDeviceiPhoneSimulatoriPad;
 
-		return UIDeviceiPhoneSimulator;
+		return UIDeviceUnknownSimulator;
 	}
 
 	return UIDeviceUnknown;
@@ -191,7 +191,7 @@
 			
 		case UIDeviceAppleTV2 : return APPLETV_2G_NAMESTRING;
 			
-		case UIDeviceiPhoneSimulator: return IPHONE_SIMULATOR_NAMESTRING;
+		case UIDeviceUnknownSimulator: return IPHONE_SIMULATOR_NAMESTRING;
 		case UIDeviceiPhoneSimulatoriPhone: return IPHONE_SIMULATOR_IPHONE_NAMESTRING;
 		case UIDeviceiPhoneSimulatoriPad: return IPHONE_SIMULATOR_IPAD_NAMESTRING;
 			
@@ -275,7 +275,7 @@
 			
 		case UIDeviceAppleTV2:	return @"K66";
 
-		case UIDeviceiPhoneSimulator: return IPHONE_SIMULATOR_NAMESTRING;
+		case UIDeviceUnknownSimulator: return IPHONE_SIMULATOR_NAMESTRING;
 			
 		default: return IPOD_FAMILY_UNKNOWN_DEVICE;
 	}

--- a/UIDevice-Hardware.m
+++ b/UIDevice-Hardware.m
@@ -123,7 +123,6 @@
 - (NSUInteger) platformType
 {
 	NSString *platform = [self platform];
-	// if ([platform isEqualToString:@"XX"])			return UIDeviceUnknown;
 	
 	if ([platform isEqualToString:@"iFPGA"])		return UIDeviceIFPGA;
 
@@ -162,6 +161,7 @@
 
 		return UIDeviceiPhoneSimulator;
 	}
+
 	return UIDeviceUnknown;
 }
 
@@ -241,7 +241,7 @@
 	ifm = (struct if_msghdr *)buf;
 	sdl = (struct sockaddr_dl *)(ifm + 1);
 	ptr = (unsigned char *)LLADDR(sdl);
-	// NSString *outstring = [NSString stringWithFormat:@"%02x:%02x:%02x:%02x:%02x:%02x", *ptr, *(ptr+1), *(ptr+2), *(ptr+3), *(ptr+4), *(ptr+5)];
+
 	NSString *outstring = [NSString stringWithFormat:@"%02x%02x%02x%02x%02x%02x", *ptr, *(ptr+1), *(ptr+2), *(ptr+3), *(ptr+4), *(ptr+5)];
 	free(buf);
 	return [outstring uppercaseString];


### PR DESCRIPTION
Hey,

This adds support for iPad 2, as well as differentiating between iPhone 4 GSM and CDMA.
I also took the liberty of cleaning up the constant names a bit, and added macros to test for groups of devices instead of single devices (like "is this an iPhone 4" and "is this an iPad").

I'm not sure if this is something you want - but at least the 3 first commits should be interesting to you.
- Jørgen.
