### PR TITLE
TARGET_IPHONE_SIMULATOR has been deprecated

### DIFF
--- a/UIDevice-Orientation.m
+++ b/UIDevice-Orientation.m
@@ -26,7 +26,7 @@ CGFloat device_angle;
 
 - (CGFloat) orientationAngle
 {
-#if TARGET_IPHONE_SIMULATOR
+#if TARGET_OS_SIMULATOR
 	switch (self.orientation)
 	{
 		case UIDeviceOrientationPortrait: 

--- a/UIDevice-Reachability.m
+++ b/UIDevice-Reachability.m
@@ -92,7 +92,7 @@ SCNetworkReachabilityRef reachability;
 	if (success != 0) return nil;
 	baseHostName[255] = '\0';
 	
-#if TARGET_IPHONE_SIMULATOR
+#if TARGET_OS_SIMULATOR
  	return [NSString stringWithFormat:@"%s", baseHostName];
 #else
 	return [NSString stringWithFormat:@"%s.local", baseHostName];


### PR DESCRIPTION
Update to use new build flag for detecting simulator. May need to include `TargetConditionals.h` if used in Swift code, which is not the case here.
